### PR TITLE
Prevent double marks in IAB without unregistering the eventlistener

### DIFF
--- a/consent-managers/iab-eu-cmp.md
+++ b/consent-managers/iab-eu-cmp.md
@@ -14,11 +14,7 @@ Assuming the user doesn't relaunch the consent dialog later each page should hav
 
 From a performance monitoring perspective `cmpuishown` and `tcloaded` seem to the the two most interesting to track. The first measures how quickly the consent dialog is displayed, the second when the CMP is ready to respond to adtech (when the dialog isn't shown)
 
-This sample creates User Timing marks for each of the three events.
-
-If the event is either `useractioncomplete` or `tcloaded` then it tries to remove the listener to prevent extra `cmpuishown` and `useractioncomplete` marks if a user manually launches the consent dialog. 
-
-Removing the listener seems to fail with some CMPs as the `tcdata.listenerId` passed in the event data isn't valid.
+This sample creates User Timing marks for each of the three events once.
 
 It should be placed directly after the CMP stub in the page
 

--- a/consent-managers/iab-eu-cmp.md
+++ b/consent-managers/iab-eu-cmp.md
@@ -28,18 +28,16 @@ It should be placed directly after the CMP stub in the page
 // Creates User Timing marks for cmpuishown, useractioncomplete & tcloaded
 if (typeof window.__tcfapi === 'function') {
     
+    let markedEvents = [];
     window.__tcfapi('addEventListener', 2, (tcdata, success) => { 
 
-        if(success) { 
+        if(success && !markedEvents.includes(tcdata.eventStatus)) { 
 
             performance.mark('tcf-' + tcdata.eventStatus); 
 
-            // Stop listending after TCF loaded, or user action complete to prevent generation
-            // of extra cpuishown & useractioncomplete marks if visitor reopens CMP UI
-            if(tcdata.eventStatus === 'useractioncomplete' || 
-               tcdata.eventStatus === 'tcloaded') {
-                window.__tcfapi('removeEventListener', 2, (success) => {  }, tcdata.tcfListenerId);
-            }
+            // Prevent listening to events twice, to prevent generation of extra 
+            // cpuishown & useractioncomplete marks if visitor reopens CMP UI
+            markedEvents.push(tcdata.eventStatus);
         }
     });
 }


### PR DESCRIPTION
Hey,

thanks for your inspiring talk today at perfnow.nl! This recommendation came in really handy for me as I am using a SourcePoint but simply was missing out on this opportunity.

From my experience, publishers often already have code listening to that event because they need to process custom vendors, want to trigger reloads, or many other things. I imagine if someone stumbles upon your snippet and just adds the inner code to their existing callback, they might run into issues when unregistering the event handler. That's why I am suggesting this alternative.

On the other side, you could argue that this is the developers responsibility, or that they just could register two event listeners and thus, that this is a workaround for a problem that might not even exits in the first place.

In that case, I am not disappointed in you rejecting this PR. Take it as feedback/heads up in that case (: